### PR TITLE
Correct bad LSB MSB math

### DIFF
--- a/src/SparkFun_TMAG5273_Arduino_Library.cpp
+++ b/src/SparkFun_TMAG5273_Arduino_Library.cpp
@@ -176,7 +176,7 @@ int8_t TMAG5273::writeRegisters(uint8_t regAddress, uint8_t *dataBuffer, uint8_t
 uint8_t TMAG5273::readRegister(uint8_t regAddress)
 {
     uint8_t regVal = 0;
-    readRegisters(regAddress, &regVal, 2);
+    readRegisters(regAddress, &regVal, 1);
     return regVal;
 }
 
@@ -2536,13 +2536,16 @@ float TMAG5273::getTemp()
 /// @return X-Channel data conversion results
 float TMAG5273::getXData()
 {
-    int8_t xLSB = readRegister(TMAG5273_REG_X_LSB_RESULT);
-    int8_t xMSB = readRegister(TMAG5273_REG_X_MSB_RESULT);
+    int8_t xLSB = 0;
+    int8_t xMSB = 0;
+
+    xLSB = readRegister(TMAG5273_REG_X_LSB_RESULT);
+    xMSB = readRegister(TMAG5273_REG_X_MSB_RESULT);
 
     // Variable to store full X data
     int16_t xData = 0;
     // Combines the two in one register where the MSB is shifted to the correct location
-    xData = -(xMSB << 8) | xLSB;
+    xData = xLSB + (xMSB << 8);
 
     // Reads to see if the range is set to 40mT or 80mT
     uint8_t rangeValXY = getXYAxisRange();
@@ -2577,7 +2580,8 @@ float TMAG5273::getYData()
 
     // Variable to store full Y data
     int16_t yData = 0;
-    yData = -(yMSB << 8) | (yLSB); // Combines the two in one register where the MSB is shifted to the correct location
+    // Combines the two in one register where the MSB is shifted to the correct location
+    yData = yLSB + (yMSB << 8); 
 
     // Reads to see if the range is set to 40mT or 80mT
     uint8_t rangeValXY = getXYAxisRange();
@@ -2613,7 +2617,7 @@ float TMAG5273::getZData()
     // Variable to store full X data
     int16_t zData = 0;
     // Combines the two in one register where the MSB is shifted to the correct location
-    zData = -(zMSB << 8) | (zLSB);
+    zData = zLSB + (zMSB << 8);
 
     // Reads to see if the range is set to 40mT or 80mT
     uint8_t rangeValZ = getZAxisRange();
@@ -2660,7 +2664,7 @@ float TMAG5273::getAngleResult()
     float finalVal = 0;
 
     // Combining the register value
-    angleReg = (angleMSB << 8) | angleLSB;
+    angleReg = angleLSB + (angleMSB << 8);
 
     // Removing the uneeded bits for the fraction value
     decValue = float(angleLSB & 0b1111) / 16;


### PR DESCRIPTION
Bit math is not my strong suit but this was not working as it was and after a lot of digging it seems like the math for combining the LSS and MSB bytes in the X/Y/Z/angle functions was bad.

Also it seems that the readRegister function was reading two bytes even though it was always using only the first. Changed this to only read one byte.