### PR TITLE
Remove check for `AngleEn` register set to 0

### DIFF
--- a/src/SparkFun_TMAG5273_Arduino_Library.cpp
+++ b/src/SparkFun_TMAG5273_Arduino_Library.cpp
@@ -81,12 +81,6 @@ int8_t TMAG5273::begin(uint8_t sensorAddress, TwoWire &wirePort)
         return 0;
     }
 
-    // Check that X and Y angle calculation is disabled
-    if (getAngleEn() != TMAG5273_NO_ANGLE_CALCULATION)
-    {
-        return 0;
-    }
-
     // returns true if all the checks pass
     return 1;
 }


### PR DESCRIPTION
Removed check for `AngleEn` register set to 0 (sparkfun/SparkFun_TMAG5273_Arduino_Library#6).

This is done to prevent failed initialization checks for applications that use the TMAG5273 for angle measurement applications (as in FOC boards). The check seems arbitrary.